### PR TITLE
Add markdownlint linter to CI build

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -37,6 +37,9 @@ jobs:
         with:
           args: -color
 
+      - name: Lint Markdown files
+        uses: articulate/actions-markdownlint@v1
+
       - name: Format, Lint, Test, and Build
         id: npm-lint
         run: npm run all

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,25 @@
+default: true
+
+# Unordered list indentation
+MD007: { indent: 2 }
+
+# Line length
+MD013: { line_length: 90, tables: false, code_blocks: false }
+
+# Heading duplication is allowed for non-sibling headings
+MD024: { siblings_only: true }
+
+# Do not allow the specified trailig punctuation in a header
+MD026: { punctuation: '.,;:' }
+
+# Order list items must have a prefix that increases in numerical order
+MD029: { style: ordered }
+
+# Lists do not need to be surrounded by blank lines
+MD032: false
+
+# Allow raw HTML in Markdown
+MD033: false
+
+# Allow emphasis to be used instead of a heading
+MD036: false

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,3 @@
+.trunk
+coverage
+node_modules

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "scripts": {
     "lint": "npm run lint:actionlint",
     "lint:actionlint": "actionlint -color",
+    "lint:markdownlint": "markdownlint '**/*.md'",
     "ci-test": "jest",
     "format": "trunk fmt --all --print-failures --show-existing",
     "lint:fix": "trunk check --all --fix --print-failures --show-existing",


### PR DESCRIPTION
Instead of depending on trunk.io, integrate markdownlint directly.